### PR TITLE
Trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ DI friendly to make it easier to test your code. You can test what happens on
 specific encode/decode errors without having to craft input that causes them.
 
 Just mock the Encoder and have it behave the way you want to test.
+
+## Encoder vs Trait
+
+There is no behavioural difference between the Encoder and the Trait.
+
+Use the Encoder version for any service class.  This let's you mock it and thus
+mock encode/decode issues without having to craft inputs that produce them.
+
+Use the Trait when you need the same functionality in a data class.
+
+## Dev
+
+This repo assumes you have a suitable version of Docker available.
+
+Copy `.env.dist` to `.env`.  It's very unlikely you'll need to update these values.
+
+Run `./bin/composer install`.
+
+The standard Leverage Toolchain scripts are available in `./vendor/bin/`.
+
+Make sure to run `./vendor/bin/verify` before you push.

--- a/src/JsonEncoder.php
+++ b/src/JsonEncoder.php
@@ -4,33 +4,10 @@ declare(strict_types=1);
 
 namespace Leverage\Encoder;
 
-use JsonException;
-use JsonSerializable;
-
 class JsonEncoder
 {
-    /**
-     * @throws JsonException
-     */
-    public function decode(
-        string $json,
-    ): mixed {
-        return json_decode(
-            json: $json,
-            associative: true,
-            flags: JSON_THROW_ON_ERROR,
-        );
-    }
-
-    /**
-     * @throws JsonException
-     */
-    public function encode(
-        array | JsonSerializable $data,
-    ): string {
-        return json_encode(
-            value: $data,
-            flags: JSON_THROW_ON_ERROR
-        );
+    use JsonTrait {
+        decode as public;
+        encode as public;
     }
 }

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leverage\Encoder;
+
+use JsonException;
+use JsonSerializable;
+
+trait JsonTrait
+{
+    /**
+     * @throws JsonException
+     */
+    private function decode(
+        string $json,
+    ): mixed {
+        return json_decode(
+            json: $json,
+            associative: true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function encode(
+        array | JsonSerializable $data,
+    ): string {
+        return json_encode(
+            value: $data,
+            flags: JSON_THROW_ON_ERROR
+        );
+    }
+}

--- a/test/JsonTraitTest.php
+++ b/test/JsonTraitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use JsonSerializable;
+use Leverage\Encoder\JsonTrait;
+use PHPUnit\Framework\TestCase;
+
+class JsonTraitTest extends TestCase
+{
+    use JsonTrait;
+
+    public function testDecode(): void
+    {
+        $data = [
+            'key' => 'val',
+        ];
+
+        /** @var string */
+        $json = json_encode($data);
+
+        self::assertSame($data, $this->decode($json));
+    }
+
+    public function testDecodeFalse(): void
+    {
+        /** @var string */
+        $json = json_encode(false);
+        self::assertFalse($this->decode($json));
+    }
+
+    public function testDecodeNull(): void
+    {
+        /** @var string */
+        $json = json_encode(null);
+        self::assertNull($this->decode($json));
+    }
+
+    public function testDecodeTrue(): void
+    {
+        /** @var string */
+        $json = json_encode(true);
+        self::assertTrue($this->decode($json));
+    }
+
+    public function testEncodeArray(): void
+    {
+        $data = ['a', 'b', 'c'];
+
+        $expected = json_encode($data);
+        self::assertSame($expected, $this->encode($data));
+    }
+
+    public function testEncodeAssocArray(): void
+    {
+        $data = [
+            'key' => 'val',
+        ];
+
+        $expected = json_encode($data);
+        self::assertSame($expected, $this->encode($data));
+    }
+
+    public function testEncodeJsonSerializable(): void
+    {
+        $data = [
+            'key' => 'val',
+        ];
+
+        $serializable = self::createMock(JsonSerializable::class);
+        $serializable->method('jsonSerialize')->willReturn($data);
+
+        $expected = json_encode($data);
+        self::assertSame($expected, $this->encode($serializable));
+    }
+}


### PR DESCRIPTION
JsonEncoder encode/decode logic is now available as a trait as well as an injectable class.

This means you can use it in a data class that you expect to mock to test behaviour such as bad encodings.
